### PR TITLE
Fix metadata parsing errors

### DIFF
--- a/data_sources/rightsholders_utils.py
+++ b/data_sources/rightsholders_utils.py
@@ -7,7 +7,9 @@ from data_sources.spotify_utils import get_spotify_metadata
 
 def get_rightsholders(artist: str, title: str) -> Dict[str, Any]:
     spotify_meta = get_spotify_metadata(artist, title)
-    label = spotify_meta.get('album', {}).get('label') if spotify_meta else None
+    # get_spotify_metadata returns label at the top level, not nested under
+    # an "album" key. Pull it directly if present.
+    label = spotify_meta.get('label') if spotify_meta else None
 
     discogs_credits = get_discogs_credits(artist, title)
     discogs_label = get_discogs_label(artist, title)

--- a/main.py
+++ b/main.py
@@ -29,7 +29,12 @@ def main(artist: str, title: str):
 
     print("Fetching Discogs master & versions...")
     discogs_master = get_discogs_master_and_versions(artist, title)
-    print(f"Discogs master data: {discogs_master['master_title']} with {len(discogs_master['versions'])} versions")
+    if discogs_master:
+        master_title = discogs_master.get('master_title', 'Unknown')
+        versions = discogs_master.get('versions', [])
+        print(f"Discogs master data: {master_title} with {len(versions)} versions")
+    else:
+        print("No Discogs master data found")
 
     print("Generating copyright flags...")
     flags = generate_copyright_flags(

--- a/templates/index.html
+++ b/templates/index.html
@@ -189,7 +189,7 @@
 
         function renderDiscogsMaster(master) {
             if (!master) return '<p>No Discogs master data found.</p>';
-            const versions = master.versions?.map(v => `<li>${v.title} by ${v.artist || 'Unknown Artist'} — <a href="${v.uri}" target="_blank">View Version</a></li>`).join('');
+            const versions = master.versions?.map(v => `<li>${v.title} by ${v.artist || 'Unknown Artist'} — <a href="${v.uri}" target="_blank">View Version</a></li>`).join('') || '';
             return `
                 <p><strong>Master Title:</strong> ${master.master_title || 'Unknown'}</p>
                 <p><strong>Master URI:</strong> <a href="${master.master_uri}" target="_blank">View Master</a></p>
@@ -198,7 +198,8 @@
         }
 
         function renderFlags(flags) {
-            return flags?.flags.map(flag => `<p>${flag}</p>`).join('') || '<p>None found.</p>';
+            const list = flags?.flags?.map(flag => `<p>${flag}</p>`).join('') || '';
+            return list || '<p>None found.</p>';
         }
 
         function capitalize(word) {


### PR DESCRIPTION
## Summary
- parse label from correct field in `get_rightsholders`
- guard against missing Discogs master details in `main`
- avoid JavaScript errors when arrays are missing

## Testing
- `python -m py_compile data_sources/rightsholders_utils.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_687cf4d115908331bdc4a8ab9f43e64b